### PR TITLE
[STATFLO-2372] - Wiring the Java SDK to Github Actions

### DIFF
--- a/.github/workflows/on-release-dispatch.yaml
+++ b/.github/workflows/on-release-dispatch.yaml
@@ -1,0 +1,62 @@
+name: Codegen automate generation
+
+on:
+  # Manually trigger the workflow for testing purposes
+  workflow_dispatch:
+    inputs:
+      release_version:
+        type: string
+        required: true
+ 
+  # Listen for the release-created event which is triggered by the webapp deploy action. https://github.com/peter-evans/repository-dispatch helps to implement Event-based communication between workflows.
+  # repository_dispatch:
+  #     types: [release-created]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      # Even though the release is handled by the webapp deploy action, the webapp still requires a significant amount of time to reflect changes on app.statflo.com
+      - name: Wait for 120 seconds # Set to 2 mins for testing
+        run: sleep 120s
+        shell: bash
+
+      # This step is used to pull the client info from the Dispatcher
+      # - name: Pull client info 
+      #   env:
+      #     PAYLOAD_CONTEXT: ${{ toJson(github.event.client_payload) }}
+      #   run: echo "$PAYLOAD_CONTEXT"
+
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Install GitHub CLI
+        run: sudo apt-get install -y gh
+
+      - name: Generate code from Swagger file
+        run: |
+          java -jar ./bin/swagger-codegen-cli-3.0.29.jar generate -i https://app.statflo.com/api/doc.json -l java -o . \
+          --invoker-package com.statflo.client \
+          --model-package com.statflo.client.model \
+          --api-package com.statflo.client.api \
+          --additional-properties groupId=com.statflo,artifactId=statflo-java-sdk
+
+      - name: Commit and Push
+        run: |
+          git config --global user.name "github-actions[bot]"
+          git config --global user.email "github-actions[bot]@users.noreply.github.com"
+          git add .
+          git commit -m "Update generated SDK (run number: ${GITHUB_RUN_NUMBER})"
+          git push origin main
+
+      # TODO: To fetch the release version from webapp using github.event.client_payload
+      - name: Create a release tag
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          # Create new tag and push
+          git tag ${{ inputs.release_version }}
+          git push origin ${{ inputs.release_version }}
+
+          gh release create ${{ inputs.release_version }} --title "Release ${{ inputs.release_version }}" --notes "Auto-generated release for ${{ inputs.release_version }}"

--- a/.github/workflows/on-release-dispatch.yaml
+++ b/.github/workflows/on-release-dispatch.yaml
@@ -15,10 +15,14 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    env:
+      SLEEP_DURATION: 120s
+      SWAGGER_URL: https://app.statflo.com/api/doc.json
+
     steps:
       # Even though the release is handled by the webapp deploy action, the webapp still requires a significant amount of time to reflect changes on app.statflo.com
-      - name: Wait for 120 seconds # Set to 2 mins for testing
-        run: sleep 120s
+      - name: Wait for environment-defined duration
+        run: sleep $SLEEP_DURATION
         shell: bash
 
       # This step is used to pull the client info from the Dispatcher
@@ -36,7 +40,7 @@ jobs:
 
       - name: Generate code from Swagger file
         run: |
-          java -jar ./bin/swagger-codegen-cli-3.0.29.jar generate -i https://app.statflo.com/api/doc.json -l java -o . \
+          java -jar ./bin/swagger-codegen-cli-3.0.29.jar generate -i $SWAGGER_URL -l java -o . \
           --invoker-package com.statflo.client \
           --model-package com.statflo.client.model \
           --api-package com.statflo.client.api \

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,9 @@
 *.war
 *.ear
 
+# exclude jar for binary build
+!/bin/*.jar 
+
 # exclude jar for gradle wrapper
 !gradle/wrapper/*.jar
 


### PR DESCRIPTION
1. For testing purposes, we will trigger the action manually.
2. Once automated generation is ready, we will switch to an Event Listener using the [peter-evans/repository-dispatch](https://github.com/peter-evans/repository-dispatch) library.
3. We will need to modify the webapp's workflow to include this step to trigger the statflo-java-sdk workflow.

```
      - name: Trigger dispatch in Repo statflo-java-sdk
        uses: peter-evans/repository-dispatch@v2
        with:
          repository: Statflo/statflo-java-sdk 
          event-type: release-created
          token: ${{ secrets.TOKEN }}
          client-payload: '{"release_version": "to_be_defined", "sha": "${{ github.sha }}"}'
```

------
Points for Discussion:

1. If we need to roll back from the webapp, it could be tricky because the automated workflow will take the release version from the webapp. In the event of a rollback, a version conflict could cause an error. We probably need to have a separate logic to handle rollback case.
2. Should we notify Slack channels to inform them when a new release is available? If yes, which channels should we notify?
