### PR TITLE
[STATFLO-2394] - Fix jitpack build

### DIFF
--- a/.swagger-codegen-ignore
+++ b/.swagger-codegen-ignore
@@ -23,3 +23,4 @@
 #!docs/README.md
 
 .gitignore
+src/main/java/com/statflo/client/model/HashMap.java


### PR DESCRIPTION
```
Picked up JAVA_TOOL_OPTIONS: -Dfile.encoding=UTF-8 -Dhttps.protocols=TLSv1.2
/home/jitpack/build/src/main/java/com/statflo/client/model/HashMap.java:17: error: com.statflo.client.model.HashMap is already defined in this compilation unit
import java.util.HashMap;
^
/home/jitpack/build/src/main/java/com/statflo/client/model/HashMap.java:24: error: type com.statflo.client.model.HashMap does not take parameters
public class HashMap extends HashMap<String, Object> {
                                    ^
/home/jitpack/build/src/main/java/com/statflo/client/model/HashMap.java:24: error: cyclic inheritance involving com.statflo.client.model.HashMap
public class HashMap extends HashMap<String, Object> {
       ^
/home/jitpack/build/src/main/java/com/statflo/client/model/HashMap.java:23: error: annotation type not applicable to this kind of declaration
@javax.annotation.Generated(value = "io.swagger.codegen.v3.generators.java.JavaClientCodegen", date = "2024-11-12T18:19:09.653356Z[Etc/UTC]")
^
4 errors

FAILURE: Build failed with an exception.
```