### PR TITLE
[STATFLO-2700] - Force codegen to use java.time.OffsetDateTime

### DIFF
--- a/.github/workflows/on-release-dispatch.yaml
+++ b/.github/workflows/on-release-dispatch.yaml
@@ -50,7 +50,8 @@ jobs:
           --invoker-package com.statflo.client \
           --model-package com.statflo.client.model \
           --api-package com.statflo.client.api \
-          --additional-properties groupId=com.statflo,artifactId=statflo-java-sdk,releaseVersion=${{ env.RELEASE_VERSION }}
+          --additional-properties groupId=com.statflo,artifactId=statflo-java-sdk,releaseVersion=${{ env.RELEASE_VERSION }} \
+          -D dateLibrary=java8
 
       - name: Commit and Push
         run: |


### PR DESCRIPTION
By default, codegen will use `org.threeten.bp.OffsetDateTime` for Date fields, which is a backport to Java SE 6 and 7.
Adding `dateLibrary=java8` will tell cli to use the modern type