### PR TITLE
[STATFLO-3866] - Allow statflo-java-sdk to be able to generate for dev environment

### DIFF
--- a/.github/workflows/cleanup-stale-branches.yaml
+++ b/.github/workflows/cleanup-stale-branches.yaml
@@ -13,7 +13,7 @@ jobs:
 
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 

--- a/.github/workflows/cleanup-stale-branches.yaml
+++ b/.github/workflows/cleanup-stale-branches.yaml
@@ -1,0 +1,66 @@
+name: Cleanup Stale Branches
+
+on:
+  schedule:
+    - cron: "0 0 1 * *" # Run on the first day of every month at midnight
+  workflow_dispatch:
+
+jobs:
+  cleanup:
+    runs-on: ubuntu-latest
+    env:
+      RETENTION_DAYS: 30
+
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Delete stale branches
+        id: cleanup
+        run: |
+          git fetch --prune origin +refs/heads/*:refs/remotes/origin/*
+          
+          CUTOFF_DATE=$(date -d "$RETENTION_DAYS days ago" +%s)
+
+          > branch_report.txt
+          deleted_count=0
+          
+          # Iterate over all remote branches except main
+          for remote_branch in $(git for-each-ref --format='%(refname:short)' refs/remotes/origin/ | grep -v '^origin/main$'); do
+            branch_name=${remote_branch#origin/}
+          
+            commit_timestamp=$(git log -1 --format=%ct origin/$branch_name)
+            commit_date=$(date -d @$commit_timestamp +"%Y-%m-%d")
+          
+            if [ "$commit_timestamp" -lt "$CUTOFF_DATE" ]; then
+              git push origin --delete $branch_name
+              echo "$branch_name|$commit_date|Deleted" >> branch_report.txt
+              deleted_count=$((deleted_count+1))
+            fi
+          done
+          
+          echo "deleted_count=$deleted_count" >> $GITHUB_OUTPUT
+
+
+      - name: Cleanup Summary
+        if: always()
+        run: |
+          echo "## 🧹 Branch Cleanup Summary" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+
+          if [ ! -s branch_report.txt ]; then
+            echo "No stale branches were deleted." >> $GITHUB_STEP_SUMMARY
+            exit 0
+          fi
+
+          echo "| Branch | Last Commit |" >> $GITHUB_STEP_SUMMARY
+          echo "|--------|------------|" >> $GITHUB_STEP_SUMMARY
+
+          while IFS="|" read -r branch date status; do
+            echo "| $branch | $date |" >> $GITHUB_STEP_SUMMARY
+          done < branch_report.txt
+
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "**Total Deleted:** ${{ steps.cleanup.outputs.deleted_count }}" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/dev-deploy.yaml
+++ b/.github/workflows/dev-deploy.yaml
@@ -19,16 +19,13 @@ jobs:
           echo "BRANCH_NAME=$BRANCH_NAME" >> $GITHUB_ENV
           echo "RELEASE_VERSION=$BRANCH_NAME" >> $GITHUB_ENV
 
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
       - name: Create and checkout unique branch
         run: |
           git checkout -b ${{ env.BRANCH_NAME }}
-
-      - name: Install GitHub CLI
-        run: sudo apt-get install -y gh
 
       - name: Download the swagger spec
         uses: dawidd6/action-download-artifact@v6

--- a/.github/workflows/dev-deploy.yaml
+++ b/.github/workflows/dev-deploy.yaml
@@ -1,0 +1,86 @@
+name: Codegen generation For Dev
+
+on:
+  workflow_dispatch:
+    inputs:
+      run_id:
+        description: "Optional Run ID for specific artifact. Leave blank to use from the latest webapp deployment."
+        required: false
+        type: string
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Generate unique branch name
+        run: |
+          BRANCH_NAME="dev_$(date +'%Y%m%d%H%M%S')"
+          echo "BRANCH_NAME=$BRANCH_NAME" >> $GITHUB_ENV
+          echo "RELEASE_VERSION=$BRANCH_NAME" >> $GITHUB_ENV
+
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Create and checkout unique branch
+        run: |
+          git checkout -b ${{ env.BRANCH_NAME }}
+
+      - name: Install GitHub CLI
+        run: sudo apt-get install -y gh
+
+      - name: Download the swagger spec
+        uses: dawidd6/action-download-artifact@v6
+        with:
+          repo: ${{ secrets.REPO }}
+          github_token: ${{ secrets.ARTIFACT_READ_ONLY }}
+          run_id: ${{ github.event.inputs.run_id || '' }}
+          workflow: statflo-webapp-deploy.yaml
+          name: webapp-artifact
+          path: ./webapp-artifact/
+          workflow_conclusion: success
+
+      - name: Generate code from Swagger file
+        run: |
+          rm -f README.md
+
+          java -jar ./bin/swagger-codegen-cli-3.0.62.jar generate \
+          -i ./webapp-artifact/nelmio-spec.json \
+          -l java \
+          -o . \
+          -t ./templates \
+          --invoker-package com.statflo.client \
+          --model-package com.statflo.client.model \
+          --api-package com.statflo.client.api \
+          --additional-properties groupId=com.statflo,artifactId=statflo-java-sdk,releaseVersion=${{ env.RELEASE_VERSION }} \
+          -D dateLibrary=java8
+
+      - name: Commit and Push to unique branch
+        run: |
+          git config --global user.name "github-actions[bot]"
+          git config --global user.email "github-actions[bot]@users.noreply.github.com"
+          git add .
+          git commit -m "Generate SDK for Dev (version: ${{ env.RELEASE_VERSION }})"
+          git push origin ${{ env.BRANCH_NAME }}
+
+      - name: Deployment Summary
+        if: always()
+        run: |
+          cat <<EOF >> $GITHUB_STEP_SUMMARY
+          ## 🚀 Deployment Summary
+          
+          | Property | Value |
+          |----------|--------|
+          | Version | ${{ env.RELEASE_VERSION }} |
+          
+          ### 📦 Maven Dependency
+          
+          \`\`\`xml
+          <dependency>
+            <groupId>com.github.Statflo</groupId>
+            <artifactId>statflo-java-sdk</artifactId>
+            <version>${{ env.RELEASE_VERSION }}</version>
+          </dependency>
+          \`\`\`
+          EOF


### PR DESCRIPTION
How does this work:

1. Since GitHub Actions can’t access the Statflo dev server directly, it will consume the artifacts uploaded by the webapp deployment. This new [PR](https://github.com/Statflo/statflows/pull/66/changes) has implemented the artifact upload job.
2. A new workflow called `Codegen Generation for Dev` will be available to build the dev codegen.
3. A new `cronjob` workflow will run on the first day of every month to clean up stale branches that were created at above